### PR TITLE
Update VCLUSTER version from 0.15.5 to 0.15.6

### DIFF
--- a/optimization/vcluster/Chart.yaml
+++ b/optimization/vcluster/Chart.yaml
@@ -5,5 +5,5 @@ description: This Chart deploys vcluster k3s by default.
 #vcluster use default k3s
 dependencies:
   - name: vcluster
-    version: 0.15.5
+    version: 0.15.6
     repository: https://charts.loft.sh


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.eNOXyB45/diff_value.yaml
	 / _' | | | | |_| |_       and /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.eNOXyB45/diff_latest_value.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned two differences
	        |___/
	
	vcluster.image
	  ± value change
	    - rancher/k3s:v1.26.0-k3s1
	    + rancher/k3s:v1.27.3-k3s1
	
	ingress
	  + one map entry added:
	    # Ingress TLS configuration
	    tls: []
	    # - secretName: tls-vcluster.local
	    #   hosts:
	    #     - vcluster.local
	