### PR TITLE
Update Victoria Metrics Operator version from 0.24.1 to 0.25.0

### DIFF
--- a/monitoring/victoria-metrics-operator/Chart.yaml
+++ b/monitoring/victoria-metrics-operator/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: This Chart deploys victoria-metrics-operator.
 dependencies:
   - name: victoria-metrics-operator
-    version: 0.24.1
+    version: 0.25.0
     repository: https://victoriametrics.github.io/helm-charts/


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.4UDbTy4Q/diff_value.yaml
	 / _' | | | | |_| |_       and /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.4UDbTy4Q/diff_latest_value.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned two differences
	        |___/
	
	(root level)
	+ three map entries added:
	  # -- Tells helm to clean up vm cr resources when uninstalling
	  cleanupCRD: false
	  cleanupImage:
	    repository: gcr.io/google_containers/hyperkube
	    tag: v1.18.0
	    pullPolicy: IfNotPresent
	  # -- Pod Topology Spread Constraints. Ref: [https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
	  topologySpreadConstraints: []
	  
	
	
	image.tag
	  ± value change
	    - v0.35.1
	    + v0.36.0
	