### PR TITLE
Update Victoria Metrics Cluster version from 0.10.4 to 0.10.5

### DIFF
--- a/monitoring/victoria-metrics-cluster/Chart.yaml
+++ b/monitoring/victoria-metrics-cluster/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 description: This Chart deploys victoria-metrics-cluster.
 dependencies:
   - name: victoria-metrics-cluster
-    version: 0.10.4
+    version: 0.10.5
     repository: https://victoriametrics.github.io/helm-charts/


### PR DESCRIPTION
	     _        __  __
	   _| |_   _ / _|/ _|  between /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.iXNS8tNx/diff_value.yaml
	 / _' | | | | |_| |_       and /var/folders/38/7j5yy3mj45n46n9j_fk385g80000gn/T/tmp.iXNS8tNx/diff_latest_value.yaml
	| (_| | |_| |  _|  _|
	 \__,_|\__, |_| |_|   returned four differences
	        |___/
	
	vmselect.image.tag
	  ± value change
	    - v1.93.0-cluster
	    + v1.93.1-cluster
	
	vminsert.image.tag
	  ± value change
	    - v1.93.0-cluster
	    + v1.93.1-cluster
	
	vmstorage.image.tag
	  ± value change
	    - v1.93.0-cluster
	    + v1.93.1-cluster
	
	vmstorage.vmbackupmanager.image.tag
	  ± value change
	    - v1.93.0-enterprise
	    + v1.93.1-enterprise
	